### PR TITLE
Update require in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please **do not use this package in production environments** - it's only meant 
 const environment = require('./environment')
 
 // with
-const sslocal = require('sslocal')
+const sslocal = require('@pat/sslocal')
 const environment = sslocal.apply(require('./environment'))
 ```
 


### PR DESCRIPTION
Since the package name is `@pat/sslocal`, that's what I had to require as well - which I think should be the case for everyone?

Also mkcert on install advised I could run `mkcert -install` to have browsers trust the cert automatically (maybe just FF?) not sure if that might be worth mentioning in the README.

Thank you so much for these libraries!!!